### PR TITLE
Corrections 1

### DIFF
--- a/002-clarifications-eval.txt
+++ b/002-clarifications-eval.txt
@@ -74,7 +74,7 @@ subsections):
         It is required for operations that are related to target
         architecture threads.
 
-        [non-normative] For example: the DW_OP_regval_type operation.
+        [non-normative] For example, the DW_OP_regval_type operation.
 
     3. A current call frame
 
@@ -89,7 +89,7 @@ subsections):
         It is required for operations that specify target architecture
         registers to support virtual unwinding of the call stack.
 
-        [non-normative] For example: the DW_OP_*reg* operations.
+        [non-normative] For example, the DW_OP_*reg* operations.
 
         If specified, it must be an active call frame in the current
         thread. Otherwise the result is undefined.
@@ -136,7 +136,7 @@ subsections):
         also provide the default address space address size if no
         current target architecture is specified.
 
-        [non-normative] For example: the DW_OP_constx and DW_OP_addrx
+        [non-normative] For example, the DW_OP_constx and DW_OP_addrx
         operations.
 
         [non-normative] Note that this compilation unit may not be the
@@ -155,7 +155,7 @@ subsections):
         It is required for operations that specify target architecture
         specific entities.
 
-        [non-normative] For example: target architecture specific
+        [non-normative] For example, target architecture specific
         entities include DWARF register identifiers, DWARF address space
         identifiers, the default address space, and the address space
         address sizes.
@@ -199,12 +199,12 @@ subsections):
 
         It is required for the DW_OP_push_object_address operation.
 
-        [non-normative] For example: the DW_AT_data_location attribute
+        [non-normative] For example, the DW_AT_data_location attribute
         on type debug information entries specifies the program object
         corresponding to a runtime descriptor as the current object when
         it evaluates its associated expression.
 
-        The result is undefined if the location descriptor is invalid
+        The result is undefined if the location description is invalid
         (see 2.6 Location Descriptions).
 
     8. An initial stack
@@ -217,7 +217,7 @@ subsections):
         their DWARF expression value with initial stack entries. In all
         other cases the initial stack is empty.
 
-        The result is undefined if any location descriptors are invalid
+        The result is undefined if any location descriptions are invalid
         (see 2.6 Location Descriptions).
 
     If the evaluation requires a context element that is not specified,
@@ -259,7 +259,7 @@ first paragraph:
 ... with the following:
 
     --------------------------------------------------------------------
-    Operations represents a postfix operation on a simple stack machine.
+    Operations represent a postfix operation on a simple stack machine.
 
     A value on the stack has a type and a literal value. It can
     represent a literal value of any supported base type of the target
@@ -270,20 +270,17 @@ first paragraph:
     an integral type that has the size of an address in the target
     architecture default address space, a target architecture defined
     endianity, and unspecified signedness.
-
-    [non-normative] The generic type is the same as the unspecified type
-    used for stack operations defined in DWARF Version 4 and before.
-
-    An integral type is a base type that has an encoding of
-    DW_ATE_signed, DW_ATE_signed_char, DW_ATE_unsigned,
-    DW_ATE_unsigned_char, DW_ATE_boolean, or any target architecture
-    defined integral encoding in the inclusive range DW_ATE_lo_user to
-    DW_ATE_hi_user.
     --------------------------------------------------------------------
 
 Insert the following after the end of the same section:
 
     --------------------------------------------------------------------
+    An integral type is a base type that has an encoding of
+    DW_ATE_signed, DW_ATE_signed_char, DW_ATE_unsigned,
+    DW_ATE_unsigned_char, DW_ATE_boolean, or any target architecture
+    defined integral encoding in the inclusive range DW_ATE_lo_user to
+    DW_ATE_hi_user.
+
     Operations can act on entries on the stack, including adding entries
     and removing entries.
 
@@ -348,6 +345,62 @@ Insert the following after the end of the same section:
         Expressions).
     --------------------------------------------------------------------
 
+Replace the first paragraph in Section 2.5.1.1 Literal Encodings:
+
+    --------------------------------------------------------------------
+    The following operations all push a value onto the DWARF stack. Operations
+    other than DW_OP_const_type push a value with the generic type, and if the
+    value of a constant in one of these operations is larger than can be stored
+    in a single stack element, the value is truncated to the element size and
+    the low-order bits are pushed on the stack.
+    --------------------------------------------------------------------
+
+with:
+
+    --------------------------------------------------------------------
+    The following operations all push a literal value onto the DWARF stack.
+
+    Operations other than DW_OP_const_type push a value V with the generic type.
+    If V is larger than the generic type, then V is truncated to the generic
+    type size and the low-order bits used.
+    --------------------------------------------------------------------
+
+In Section 2.5.1.1 Literal Encodings, replace the description of the following
+operations:
+
+    --------------------------------------------------------------------
+    1.  DW_OP_lit0, DW_OP_lit1, ..., DW_OP_lit31
+        DW_OP_lit<N> operations encode an unsigned literal value N from 0
+        through 31, inclusive. They push the value N with the generic type.
+    
+    3.  DW_OP_const1u, DW_OP_const2u, DW_OP_const4u, DW_OP_const8u
+        DW_OP_const<N>u operations have a single operand that is a 1, 2, 4, or
+        8-byte unsigned integer constant U, respectively. They push the value U
+        with the generic type.
+    
+    4.  DW_OP_const1s, DW_OP_const2s, DW_OP_const4s, DW_OP_const8s
+        DW_OP_const<N>s operations have a single operand that is a 1, 2, 4, or
+        8-byte signed integer constant S, respectively. They push the value S
+        with the generic type.
+    
+    5.  DW_OP_constu
+        DW_OP_constu has a single unsigned LEB128 integer operand N. It pushes
+        the value N with the generic type.
+    
+    6.  DW_OP_consts
+        DW_OP_consts has a single signed LEB128 integer operand N. It pushes the
+        value N with the generic type.
+    
+    8.  DW_OP_constx
+        DW_OP_constx has a single unsigned LEB128 integer operand that
+        represents a zero-based index into the .debug_addr section relative to
+        the value of the DW_AT_addr_base attribute of the associated compilation
+        unit. The value N in the .debug_addr section has the size of the generic
+        type. It pushes the value N with the generic type.
+    
+        [non-normative] The DW_OP_constx... [same]
+    --------------------------------------------------------------------
+
 In Section 2.5.1.1 Literal Encodings, replace the description of
 DW_OP_const_type with the following:
 
@@ -410,7 +463,7 @@ DW_OP_regval_type with the following:
     > does not cause any test failures in common architectures. If the
     > compiler for a target architecture did want some form of
     > conversion, including a larger result type, it could always
-    > explicitly used the DW_OP_convert operation.
+    > explicitly use the DW_OP_convert operation.
     >
     > If T is a larger type than the register size, then the default GDB
     > register hook reads bytes from the next register (or reads out of
@@ -506,6 +559,10 @@ Replace the description of DW_OP_deref_type with the following:
     divided by 8 (the byte size) and rounded up to a whole number is not
     equal to S.
     --------------------------------------------------------------------
+
+    > [For further discussion...]
+    > This definition allows the base type to be a bit size since there seems no
+    > reason to restrict it.
 
 Replace the description of DW_OP_xderef with the following:
 
@@ -712,10 +769,11 @@ DW_OP_entry_value with the following:
     Otherwise, the DWARF expression is ill-formed.
     --------------------------------------------------------------------
 
-In Section 2.6.1.1.3 Register Location Descriptions, in the description
-of DW_OP_reg0...DW_OP_reg31, change "The object addressed is in register
-n" with "The target architecture register number R corresponds to the N
-in the operation name."
+In Section 2.6.1.1.3 Register Location Descriptions, in the description of
+DW_OP_reg0...DW_OP_reg31, change "The DW_OP_reg<n> operations encode the
+names..." with "The DW_OP_reg<n> operations encode the numbers...", and change
+"The object addressed is in register n" with "The target architecture register
+number R corresponds to the N in the operation name."
 
 Add the following paragraph at the end of the description of
 DW_OP_reg0...DW_OP_reg31:
@@ -723,6 +781,8 @@ DW_OP_reg0...DW_OP_reg31:
     --------------------------------------------------------------------
     The operation is equivalent to performing DW_OP_regx R.
     --------------------------------------------------------------------
+
+2.6.1.1.3 Register Location Descriptions
 
 In Section 7.4, 32-Bit and 64-Bit DWARF Formats, in item 3, add the following
 row to the table:

--- a/003-clarifications-loc.txt
+++ b/003-clarifications-loc.txt
@@ -92,16 +92,16 @@ With the following:
     [non-normative] Location descriptions are a language independent
     representation of addressing rules.
 
-        They can be the result of evaluating a debugger information
-        entry attribute that specifies an operation expression of
+      * [non-normative] They can be the result of evaluating a debugger
+        information entry attribute that specifies an operation expression of
         arbitrary complexity. In this usage they can describe the
         location of an object as long as its lifetime is either static
         or the same as the lexical block (see 3.5 Lexical Block Entries)
         that owns it, and it does not move during its lifetime.
 
-        They can be the result of evaluating a debugger information
-        entry attribute that specifies a location list expression. In
-        this usage they can describe the location of an object that has
+      * [non-normative] They can be the result of evaluating a debugger
+        information entry attribute that specifies a location list expression.
+        In this usage they can describe the location of an object that has
         a limited lifetime, changes its location during its lifetime, or
         has multiple locations over part or all of its lifetime.
 
@@ -161,23 +161,23 @@ With the following:
     [non-normative] Examples of context that can invalidate a location
     description are:
 
-      * The thread context is required and execution causes the thread
-        to terminate.
+      * [non-normative] The thread context is required and execution causes the
+        thread to terminate.
 
-      * The call frame context is required and further execution causes
-        the call frame to return to the calling frame.
+      * [non-normative] The call frame context is required and further execution
+        causes the call frame to return to the calling frame.
 
-      * The program location is required and further execution of the
-        thread occurs. That could change the location list entry or call
+      * [non-normative] The program location is required and further execution
+        of the thread occurs. That could change the location list entry or call
         frame information entry that applies.
 
-      * An operation uses call frame information:
+      * [non-normative] An operation uses call frame information:
 
-          * Any of the frames used in the virtual call frame unwinding
-            return.
+          * [non-normative] Any of the frames used in the virtual call frame
+            unwinding return.
 
-          * The top call frame is used, the program location is used to
-            select the call frame information entry, and further
+          * [non-normative] The top call frame is used, the program location is
+            used to select the call frame information entry, and further
             execution of the thread occurs.
 
     [non-normative] A DWARF expression can be used to compute a location

--- a/004-clarifications-cfi.txt
+++ b/004-clarifications-cfi.txt
@@ -31,10 +31,10 @@ after the first sentence:
     --------------------------------------------------------------------
 
 Change the parenthetical comment, "By convention, ...," to non-normative
-text.
+text and change "it" to "the register".
 
-For the "same value" register rule, add the following after the first
-sentence:
+For the "same value" register rule change "frame" to "caller frame", and add the
+following paragraphs after the first sentence:
 
     --------------------------------------------------------------------
     If the current frame is the top frame, then the previous value of
@@ -50,7 +50,7 @@ sentence:
     --------------------------------------------------------------------
 
 Change the parenthetical comment, "By convention, ...," to non-normative
-text.
+text and change "it" to "the register".
 
 For the "offset(N)" register rule, replace the description with the
 following:
@@ -77,12 +77,12 @@ following:
     does not match the size of an address in the target architecture
     default address space.
 
-    Since the CFA location description is required to be a memory byte
-    address location description, the value of val_offset(N) will also
-    be a memory byte address location description since it is offsetting
+    [non-normative] Since the CFA location description is required to be a
+    memory byte address location description, the value of val_offset(N) will
+    also be a memory byte address location description since it is offsetting
     the CFA location description by N bytes. Furthermore, the value of
-    val_offset(N) will be a memory byte address in the target
-    architecture default address space.
+    val_offset(N) will be a memory byte address in the target architecture
+    default address space.
     --------------------------------------------------------------------
 
     > [For further discussion...]
@@ -98,9 +98,12 @@ following:
     > for smaller registers. There are no GDB tests that read a register
     > out of bounds (except an illegal hand written assembly test).
 
-For the "register(R)" register rule, add the following:
+For the "register(R)" register rule, replace the description with the
+following:
 
     --------------------------------------------------------------------
+    This register has been stored in another register numbered R.
+
     The previous value of this register is the location description
     obtained using the call frame information for the current frame and
     current program location for register R.
@@ -115,10 +118,14 @@ For the "register(R)" register rule, add the following:
     > the value stored in the low order bits and it is undefined what is
     > stored in the extra upper bits?
 
-For the "expression(E)" register rule, change "executing" to
-"evaluating," and add the following:
+For the "expression(E)" register rule, replace the description with the
+following:
 
     --------------------------------------------------------------------
+    The previous value of this register is located at the location description
+    produced by evaluating the DWARF operation expression E (see 2.5.4 DWARF
+    Operation Expressions).
+
     E is evaluated with the current context, except the result kind is a
     location description, the compilation unit is unspecified, the
     object is unspecified, and an initial stack comprising the location
@@ -126,10 +133,13 @@ For the "expression(E)" register rule, change "executing" to
     Expressions).
     --------------------------------------------------------------------
 
-For the "val_expression(E)" register rule, change "executing" to
-"evaluating," and add the following:
+For the "val_expression(E)" register rule, replace the description with the
+following:
 
     --------------------------------------------------------------------
+    The previous value of this register is the value produced by evaluating the
+    DWARF operation expression E (see 2.5.4 DWARF Operation Expressions).
+
     E is evaluated with the current context, except the result kind is a
     value, the compilation unit is unspecified, the object is
     unspecified, and an initial stack comprising the location
@@ -147,6 +157,20 @@ For the "val_expression(E)" register rule, change "executing" to
     > expression. This makes it unusable for registers that are larger
     > than the generic type. However, expression(E) can be used to
     > create an implicit location description of any size.
+
+Change the paragraph that begins:
+
+    --------------------------------------------------------------------
+    A Common Information Entry holds information that is shared among many Frame
+    Description Entries. 
+    --------------------------------------------------------------------
+
+to:
+
+    --------------------------------------------------------------------
+    A Common Information Entry (CIE) holds information that is shared among many
+    Frame Description Entries (FDE).
+    --------------------------------------------------------------------
 
 In the subsection on CIE, in item 1 (length), change "...of the address
 size" to "...of the address size specified in the address_size field."
@@ -168,7 +192,11 @@ In item 3 (version), add the following:
     > [For further discussion...]
     > Should this be increased to 5?
 
-In item 9 (return_address_register), add the following:
+In item 4 (augmentation), change " target-specific information" to "vendor and
+target architecture specific information".
+
+In item 9 (return_address_register), change "function" to "subprogram", and add
+the following:
 
     --------------------------------------------------------------------
     The value of the return address register is used to determine the
@@ -177,13 +205,16 @@ In item 9 (return_address_register), add the following:
     current thread.
     --------------------------------------------------------------------
 
+In the subsection on FDE, in item 1 (length), change "function" to "subprogram".
+
 In Section 6.4.2 Call Frame Instructions, in the second paragraph,
 change "...encoded as DWARF expressions" to "...encoded as DWARF
 operation expressions E." Change the following sentence to "The DWARF
 operations that can be used in E have the following restrictions:".
 
-In the first bullet item, add the following opcodes to the list:
-DW_OP_fbreg, DW_OP_implicit_pointer, DW_OP_xderef_type.
+In the first bullet item, add the following opcodes to the list: DW_OP_fbreg,
+DW_OP_implicit_pointer, DW_OP_xderef_type. Change "operators are not allowed in
+an operand of these instructions" to "operations are not allowed".
 
 Change the second bullet to:
 
@@ -196,9 +227,12 @@ In the third bullet, add DW_OP_entry_value. Change "is not
 meaningful...because its use would be circular" to "are not allowed
 because their use would be circular."
 
-In Section 6.4.2.2 CFA Definition Instructions, in item 1,
-DW_CFA_def_cfa, replace "offset" with "byte displacement B." Change the
-second sentence to the following:
+In the last paragraph, change "DW_CFA_expression and DW_CFA_val_expression" to
+"DW_CFA_expression, and DW_CFA_val_expression".
+
+In Section 6.4.2.2 CFA Definition Instructions, in item 1, DW_CFA_def_cfa,
+replace "register number" by "register number R", and replace "offset" with
+"byte displacement B." Change the second sentence to the following:
 
     --------------------------------------------------------------------
     The required action is to define the current CFA rule to be the
@@ -206,8 +240,9 @@ second sentence to the following:
     as a location description.
     --------------------------------------------------------------------
 
-In item 2, DW_CFA_def_cfa_sf, replace "offset" with "byte displacement
-B." Change the second sentence to the following:
+In item 2, DW_CFA_def_cfa_sf, replae "register number" with "register number R",
+and replace "offset" with "byte displacement B." Change the second and third
+sentence to the following:
 
     --------------------------------------------------------------------
     The required action is to define the current CFA rule to be the
@@ -215,10 +250,20 @@ B." Change the second sentence to the following:
     B * data_alignment_factor as a location description.
     --------------------------------------------------------------------
 
+Add the following paragraph:
+
+    --------------------------------------------------------------------
+    [non-normative] The action is the same as DW_CFA_def_cfa, except that the
+    second operand is signed and factored.
+    --------------------------------------------------------------------
+
     > [For further discussion...]
     > (ccoutant) I don't see what was wrong with the original DWARF 5
     > description, which simply defines the operation in terms of the
     > preceding one.
+    >
+    > (ttye) Formally defining what "except that the second operand is signed
+    > and factored" means seems clearer.
 
 Replace the text of item 3, DW_CFA_def_cfa_register, with the following:
 
@@ -277,8 +322,8 @@ following:
     the result kind is a location description, the compilation unit is
     unspecified, the object is unspecified, and an empty initial stack.
 
-    See 6.4.2 Call Frame Instructions regarding restrictions on the
-    DWARF expression operations that can be used in E.
+    [non-normative] See 6.4.2 Call Frame Instructions regarding restrictions on
+    the DWARF expression operations that can be used in E.
 
     The DWARF is ill-formed if the result of evaluating E is not a
     memory byte address location description.
@@ -300,23 +345,28 @@ Replace the text of item 3, DW_CFA_offset, with the following:
 	data_alignment_factor) rule.
     --------------------------------------------------------------------
 
-In item 4, DW_CFA_offset_extended, change "a register number and a
-factored offset" with "a register number R and a factored offset B."
+In item 4, DW_CFA_offset_extended, change "a register number and a factored
+offset" with "a register number R and a factored displacement B", and add a
+comma before "except.
 
-In item 5, DW_CFA_offset_extended_sf, change "a register number and a
-signed LEB128 factored offset" with "a register number R and a signed
-LEB128 factored displacement B." Change the final sentence to "The
-resulting offset is B * data_alignment_factor."
+In item 5, DW_CFA_offset_extended_sf, change "a register number and a signed
+LEB128 factored offset" with "a register number R and a signed LEB128 factored
+displacement B." Change the final two sentences to "This instruction is
+identical to DW_CFA_offset_extended, except that B is signed."
 
-In item 6, DW_CFA_val_offset, change "a register number and a factored
-offset" to "a register number R and a factored displacement B." Change
-"a val_offset(N) rule where..." to "a val_offset(B *
-data_alignment_factor) rule."
+In item 6, DW_CFA_val_offset, change "a register number and a factored offset"
+to "a register number R and a factored displacement B."  Change "indicated by
+the register number to be a val_offset(N) rule where..." to "indicated by R to
+be a val_offset(B * data_alignment_factor) rule."
 
-In item 7, DW_CFA_val_offset_sf, change "a register number and a
-factored offset" to "a register number R and a factored displacement B."
-Change "except that the second operand is signed and factored" to
-"except the B is signed."
+Replace the text of item 7, DW_CFA_val_offset_sf, with the following:
+
+    --------------------------------------------------------------------
+    The DW_CFA_val_offset_sf instruction takes two operands: an unsigned LEB128
+    value representing a register number R and a signed LEB128 factored
+    displacement B. This instruction is identical to DW_CFA_val_offset, except
+    that B is signed.
+    --------------------------------------------------------------------
 
 Replace the text of item 8, DW_CFA_register, with the following:
 
@@ -327,37 +377,42 @@ Replace the text of item 8, DW_CFA_register, with the following:
 	register(R2) rule.
     --------------------------------------------------------------------
 
-In item 9, DW_CFA_expression, change "a register number" to "a register
-number R," and change "a DWARF expression" to "a DWARF operation
-expression E." Change "the register indicated by the register number" to
-"the register specified by R." Replace the end of the paragraph starting
-from "That is" with the following:
+In item 9, DW_CFA_expression, replace the description with the following:
 
     --------------------------------------------------------------------
+    The DW_CFA_expression instruction takes two operands: an unsigned LEB128
+    value representing a register number R, and a DW_FORM_block value
+    representing a DWARF operation expression E. The required action is to
+    change the rule for the register specified by R to be an expression(E) rule.
+
 	[non-normative] That is, E computes the location description where
 	the register value can be retrieved.
+
+    [non-normative] See 6.4.2 Call Frame Instructions regarding restrictions on
+    the DWARF expression operations that can be used in E.
     --------------------------------------------------------------------
 
-In the non-normative paragraph beginning "See Section 6.4.2", change
-"that can be used" to "that can be used in E."
-
-In item 10, DW_CFA_val_expression, change "a register number" to "a
-register number R," and change "a DWARF expression" to "a DWARF
-operation expression E." Change "the register indicated by the register
-number" to "the register specified by R." Remove "where E is the DWARF
-expression." Replace the end of the paragraph starting from "That is"
-with the following:
+In item 10, DW_CFA_val_expression, replace the description with the following:
 
     --------------------------------------------------------------------
-	[non-normative] That is, E computes the value of register R.
-    --------------------------------------------------------------------
+    The DW_CFA_val_expression instruction takes two operands: an unsigned
+    LEB128 value representing a register number R, and a DW_FORM_block value
+    representing a DWARF operation expression E. The required action is to
+    change the rule for the register specified by R to be a val_expression(E)
+    rule.
 
-In the non-normative paragraph beginning "See Section 6.4.2", change
-"that can be used" to "that can be used in E."
+    [non-normative] That is, E computes the value of register R.
+
+    [non-normative] See 6.4.2 Call ßFrame Instructions regarding restrictions on
+    the DWARF expression operations that can be used in E.
+
+    If the result of evaluating E is not a value with a base type size that
+    matches the register size, then the DWARF is ill-formed.
+    --------------------------------------------------------------------
 
 In item 11, DW_CFA_restore, change "a register number" to "a register
 number R." Change "the indicated register" to "the register specified by
 R."
 
 In item 12, DW_CFA_restore_extended, change "a register number" to "a
-register number R."
+register number R", and add a comma before "except".

--- a/005-clarifications-mem.txt
+++ b/005-clarifications-mem.txt
@@ -1,19 +1,20 @@
-Part 5: Address Spaces
+Part 5: Clarifications for Memory Location Descriptions
 
-This is part 5 in a series of proposals related to support for debugging
-on heterogeneous architectures. This proposal lays more groundwork for
-subsequent proposals by introducing the concept of multiple address
-spaces, which heretofore had only been alluded to in the spec (See
-Section 1.3.2).
+This is part 5 in a series of proposals related to support for debugging on
+heterogeneous architectures. This proposal lays more groundwork for subsequent
+proposals by introducing the concept of addressable memory storage that is
+associated with each address space supported by a target architecture, which
+heretofore had only been alluded to in the spec (See Section 1.3.2).
 
 
 BACKGROUND
 ----------
 
-The changes proposed below introduce the concept of an address space,
-and a default address space for the target architecture. Subsequent
-proposals will make use of this, allowing location descriptions to
-specify address spaces other than the default one.
+The changes proposed below introduce the concept of distinct memory storage for
+each address space supported by a target architecture, and a default address
+space for the target architecture. Subsequent proposals will make use of this,
+allowing memory location descriptions to specify address spaces other than the
+default one.
 
 
 PROPOSED CHANGES
@@ -61,7 +62,4 @@ paragraph:
     location description SL is defined to be a memory byte address
     location description. It has a byte address equal to A and an
     address space equal to AS of the corresponding SL.
-
-    DW_ASPACE_none is defined as the target architecture default address
-    space.
     --------------------------------------------------------------------

--- a/006-locations-on-stack.txt
+++ b/006-locations-on-stack.txt
@@ -78,6 +78,18 @@ and change "A value on the stack has..." to "A value has...":
     DW_ATE_hi_user.
     --------------------------------------------------------------------
 
+    > [For further discussion...]
+    > It may be desirable to add an implicit pointer base type encoding.
+    > It would be used for the type of the value that is produced when
+    > the DW_OP_deref* operation retrieves the full contents of an
+    > implicit pointer location storage created by the
+    > DW_OP_implicit_pointer operation. The literal value would record
+    > the debugging information entry and byte displacement specified by
+    > the associated DW_OP_implicit_pointer operation.
+    >
+    > It is unclear if DW_ATE_address is an integral type. GDB does not
+    > seem to consider it as integral.
+
 Rename the subsection 2.5.x General Operations:
 
     --------------------------------------------------------------------
@@ -108,17 +120,9 @@ Insert the following after the same paragraph:
     operation expression is ill-formed.
     --------------------------------------------------------------------
 
-    > [For further discussion...]
-    > It may be desirable to add an implicit pointer base type encoding.
-    > It would be used for the type of the value that is produced when
-    > the DW_OP_deref* operation retrieves the full contents of an
-    > implicit pointer location storage created by the
-    > DW_OP_implicit_pointer operation. The literal value would record
-    > the debugging information entry and byte displacement specified by
-    > the associated DW_OP_implicit_pointer operation.
-    >
-    > It is unclear if DW_ATE_address is an integral type. GDB does not
-    > seem to consider it as integral.
+Change the paragraph starting "Evaluation of an expression starts with an empty
+stack..." to "Evaluation of an operation expression starts with an empty
+stack...".
 
 Near the end of the section, under the first-level bullet item that
 begins "If the current result kind specifies a location description":
@@ -147,7 +151,7 @@ empty..." with the following:
     --------------------------------------------------------------------
 
 Under the first-level bullet item beginning "If the current result kind
-specifies a location description," replace the second-level bullet
+specifies a value," replace the second-level bullet
 beginning "If the stack is not empty" with the following:
 
     --------------------------------------------------------------------
@@ -316,11 +320,22 @@ following:
     where N is limited to the size of PL.
 
     V is pushed on the stack with the type T.
-
-    See 2.5.x.x Implicit Location Description Operations for special
-    rules concerning implicit location descriptions created by the
-    DW_OP_implicit_pointer operation.
     --------------------------------------------------------------------
+
+    > [For further discussion...]
+    > This definition makes it an evaluation error if L is a register location
+    > description that has less than TS bits remaining in the register storage.
+    > Particularly since these extensions extend location descriptions to have a
+    > bit offset, it would be odd to define this as performing sign extension
+    > based on the type, or be target architecture dependent, as the number of
+    > remaining bits could be any number. This matches the GDB implementation
+    > for DW_OP_deref_type.
+    >
+    > These extensions define DW_OP_*breg* in terms of DW_OP_regval_type.
+    > DW_OP_regval_type is defined in terms of DW_OP_regx, which uses a 0 bit
+    > offset, and DW_OP_deref_type. Therefore, it requires the register size to
+    > be greater or equal to the address size of the address space. This matches
+    > the GDB implementation for DW_OP_*breg*.
 
 Add the following to the end of the description of DW_OP_deref_type:
 
@@ -330,7 +345,7 @@ Add the following to the end of the description of DW_OP_deref_type:
     size of the location storage LS specified by any single location
     description SL of L.
 
-    See 2.6.1.1.4 Implicit Location Descriptions for special
+    See 2.5.x.x Implicit Location Description Operations for special
     rules concerning implicit location descriptions created by the
     DW_OP_implicit_pointer operation.
     --------------------------------------------------------------------
@@ -441,8 +456,8 @@ with the following:
     --------------------------------------------------------------------
     DW_OP_call_frame_cfa pushes the location description L of the
     Canonical Frame Address (CFA) of the current subprogram, obtained
-    from the call frame information on the stack. (See Section 6.4 Call
-    Frame Information.)
+    from the call frame information on the stack. See Section 6.4 Call
+    Frame Information.
 
     [non-normative] Although the value of the DW_AT_frame_base attribute
     of the debugger information entry corresponding to the current
@@ -466,6 +481,79 @@ call operation is evaluated by":
         is the one that contains D, and the initial stack is empty. The
         location description result is pushed on the stack.
 
+        > [For further discussion...]
+        > This rule avoids having to define how to execute a matched location
+        > list entry operation expression on the same stack as the call when
+        > there are multiple matches. But it allows the call to obtain the
+        > location description for a variable or formal parameter which may use
+        > a location list expression.
+        >
+        > An alternative is to treat the case when D has a DW_AT_location
+        > attribute that is encoded as a loclist or loclistsptr, and the
+        > specified location list expression E' matches a single location list
+        > entry with operation expression E, the same as the exprloc case and
+        > evaluate on the same stack.
+        >
+        > But this is not attractive as if the attribute is for a variable that
+        > happens to end with a non-singleton stack, it will not simply put a
+        > location description on the stack. Presumably the intent of using
+        > DW_OP_call* on a variable or formal parameter debugger information
+        > entry is to push just one location description on the stack. That
+        > location description may have more than one single location
+        > description.
+        >
+        > The previous rule for exprloc also has the same problem, as normally a
+        > variable or formal parameter location expression may leave multiple
+        > entries on the stack and only return the top entry.
+        >
+        > GDB implements DW_OP_call* by always executing E on the same stack. If
+        > the location list has multiple matching entries, it simply picks the
+        > first one and ignores the rest. This seems fundamentally at odds with
+        > the desire to support multiple places for variables.
+        >
+        > So, it feels like DW_OP_call* should both support pushing a location
+        > description on the stack for a variable or formal parameter, and also
+        > support being able to execute an operation expression on the same
+        > stack. Being able to specify a different operation expression for
+        > different program locations seems a desirable feature to retain.
+        >
+        > A solution to that is to have a distinct DW_AT_proc attribute for the
+        > DW_TAG_dwarf_procedure debugging information entry. Then the
+        > DW_AT_location attribute expression is always executed separately and
+        > pushes a location description (that may have multiple single location
+        > descriptions), and the DW_AT_proc attribute expression is always
+        > executed on the same stack and can leave anything on the stack.
+        >
+        > The DW_AT_proc attribute could have the new classes exprproc,
+        > loclistproc, and loclistsptrproc to indicate that the expression is
+        > executed on the same stack. exprproc is the same encoding as exprloc.
+        > loclistproc and loclistsptrproc are the same encoding as their
+        > non-proc counterparts, except the DWARF is ill-formed if the location
+        > list does not match exactly one location list entry and a default
+        > entry is required. These forms indicate explicitly that the matched
+        > single operation expression must be executed on the same stack. This
+        > is better than ad hoc special rules for loclistproc and
+        > loclistsptrproc which are currently clearly defined to always return a
+        > location description. The producer then explicitly indicates the
+        > intent through the attribute classes.
+        >
+        > Such a change would be a breaking change for how GDB implements
+        > DW_OP_call*. However, are the breaking cases actually occurring in
+        > practice? GDB could implement the current approach for DWARF Version
+        > 5, and the new semantics for DWARF Version 6 which has been done for
+        > some other features.
+        >
+        > Another option is to limit the execution to be on the same stack only
+        > to the evaluation of an expression E that is the value of a
+        > DW_AT_location attribute of a DW_TAG_dwarf_procedure debugging
+        > information entry. The DWARF would be ill-formed if E is a location
+        > list expression that does not match exactly one location list entry.
+        > In all other cases the evaluation of an expression E that is the value
+        > of a DW_AT_location attribute would evaluate E with the current
+        > context, except the result kind is a location description, the
+        > compilation unit is the one that contains D, and the initial stack is
+        > empty. The location description result is pushed on the stack.
+  
       * If D has a DW_AT_const_value attribute with a value V, then it
         is as if a DW_OP_implicit_value V operation was executed.
 
@@ -474,10 +562,18 @@ call operation is evaluated by":
         parameter regardless of whether the producer has optimized it to
         a constant. This is consistent with the DW_OP_implicit_pointer
         operation.
+
+        > [For further discussion...]
+        > Alternatively, could deprecate using DW_AT_const_value for
+        > DW_TAG_variable and DW_TAG_formal_parameter debugger information
+        > entries that are constants and instead use DW_AT_location with an
+        > operation expression that results in a location description with one
+        > implicit location description. Then this rule would not be required.
     --------------------------------------------------------------------
 
-In Section 2.6.1.1.2 Memory Location Descriptions (now 2.6.2), add the
-following after the first paragraph:
+In Section 2.6.1.1.2 Memory Location Descriptions (now 2.6.2), delete the first
+paragraph "A memory location description consists of a non-empty DWARF
+expression", and add the following paragraphs to the end of the section:
 
     --------------------------------------------------------------------
     If a stack entry is required to be a location description, but it is
@@ -573,19 +669,35 @@ Replace the description of DW_OP_regx with the following:
     of the access operation.
     --------------------------------------------------------------------
 
-In Section 2.6.1.1.4 (now 2.6.4) Implicit Location Descriptions, rename the section "Implicit Location Description Operations."
-
-In the first paragraph, replace “either known or known to be undefined”
-with “known, either as a constant or by computations on other locations
-and values in the program.” Add the following paragraph after the first:
+Replace the last paragraph with:
 
     --------------------------------------------------------------------
+    [non-normative] These operations obtain a register location. To fetch the
+    contents of a register, it is necessary to use DW_OP_regval_type, use one of
+    the DW_OP_breg* register-based addressing operations, or use DW_OP_deref* on
+    a register location description.
+    --------------------------------------------------------------------
+
+In Section 2.6.1.1.4 (now 2.6.4) Implicit Location Descriptions, rename the
+section "Implicit Location Description Operations."
+
+Replace the first paragraph with:
+
+    --------------------------------------------------------------------
+    Implicit location storage represents a piece or all of an object which has
+    no actual location in the program but whose contents are nonetheless known,
+    either as a constant or can be computed from other locations and values in
+    the program.
+
     An implicit location description specifies an implicit location
     storage. The bit offset corresponds to a bit position within the
     implicit location storage. Bits accessed using an implicit location
     description, access the corresponding implicit storage value
     starting at the bit offset.
     --------------------------------------------------------------------
+
+Delete the following paragraph that begins with "The following DWARF operations
+may be used...".
 
 Replace the description of DW_OP_implicit_value with the following:
 
@@ -682,7 +794,7 @@ Replace the description of DW_OP_implicit_pointer with the following:
 
         [non-normative] Note that all bits do not have to come from the
         same implicit location description, as L’ may involve composite
-        location descriptors.
+        location descriptions.
 
      2. The bits come from consecutive ascending offsets within their
         respective implicit location storage.
@@ -742,7 +854,11 @@ Replace the description of DW_OP_implicit_pointer with the following:
     description created by DW_OP_implicit_pointer can be used are to
     simplify the DWARF consumer. Similarly, for an implicit pointer
     value created by DW_OP_deref* and DW_OP_stack_value.
+    --------------------------------------------------------------------
 
+Add the following paragraphs after the description of DW_OP_implicit_pointer:
+
+    --------------------------------------------------------------------
     [non-normative] Typically a DW_OP_implicit_pointer operation is used
     in a DWARF expression E1 of a DW_TAG_variable or
     DW_TAG_formal_parameter debugging information entry D1’s
@@ -762,6 +878,19 @@ Replace the description of DW_OP_implicit_pointer with the following:
     reconstruct the value of the object when asked to dereference the
     pointer described by E1 which contains the DW_OP_implicit_pointer
     operation.
+    --------------------------------------------------------------------
+
+Delete the final paragraph:
+
+    --------------------------------------------------------------------
+    [non-normative] DWARF location descriptions are intended to yield the
+    location of a value rather than the value itself. An optimizing compiler may
+    perform a number of code transformations where it becomes impossible to give
+    a location for a value, but it remains possible to describe the value
+    itself. Section 2.6.1.1.3 on page 39 describes operators that can be used to
+    describe the location of a value when that value exists in a register but
+    not in memory. The operations in this section are used to describe values
+    that exist neither in memory nor in a single register.
     --------------------------------------------------------------------
 
 In Section 2.6.1.2 (now 2.6.5) Composite Location Descriptions, rename
@@ -948,6 +1077,9 @@ Remove the first three paragraphs ("Location lists are used in place
 of...," “A location list is indicated by...,” and “This location list
 representation, the loclist class, ...”).
 
+Change the beginning of the following paragraph from "A location list
+consists..." to "A location list expression consists...".
+
 Replace the text of Item 1, Bounded location description, with the
 following:
 
@@ -967,15 +1099,38 @@ following:
     addresses.
     --------------------------------------------------------------------
 
-In the text of Item 2, Default location description, replace “provides a
-location description that specifies the location of an object that is
-valid when no bounded location description applies” with “provides an
-operation expression that evaluates to the location description of an
-object that is valid when no bounded location description entry
-applies.”
+Replace the text of Item 2, Default location description, with the following:
 
-In the text of Item 4, End-of-list, replace “location list” with
-“location list expression.”
+    --------------------------------------------------------------------
+    This kind of location list entry provides an operation expression that
+    evaluates to the location description of an object that is valid when no
+    bounded location description entry applies.
+
+    The location list entry matches when the current program location is not
+    within the range of any bounded location description entry.
+    --------------------------------------------------------------------
+
+Replace the text of Item 3, Base address, with the following:
+
+    --------------------------------------------------------------------
+    This kind of location list entry provides an address to be used as the base
+    address for beginning and ending address offsets given in certain kinds of
+    bounded location description entries. The applicable base address of a
+    bounded location description entry is the address specified by the closest
+    preceding base address entry in the same location list. If there is no
+    preceding base address entry, then the applicable base address defaults to
+    the base address of the compilation unit (see section 3.1.1).
+
+    In the case of a compilation unit where all of the machine code is contained
+    in a single contiguous section, no base address entry is needed.
+    --------------------------------------------------------------------
+
+Replace the text of Item 4, End-of-list, with the following:
+
+    --------------------------------------------------------------------
+    This kind of location list entry marks the end of the location list
+    expression.
+    --------------------------------------------------------------------
 
 Remove the paragraph beginning "A location list consists of a sequence
 of..."
@@ -1096,8 +1251,8 @@ following:
     This computes the frame base memory location description in the
     target architecture default address space.
 
-    This allows the more compact DW_OP_reg* to be used instead of
-    DW_OP_breg* 0.
+    [non-normative] This allows the more compact DW_OP_reg* to be used instead
+    of DW_OP_breg* 0.
 
     > [For further discussion...]
     > This rule could be removed and require the producer to create the
@@ -1111,8 +1266,8 @@ following:
 
     The resulting L is the frame base for the subprogram or entry point.
 
-    Typically, E will use the DW_OP_call_frame_cfa operation or be a
-    stack pointer register plus or minus some offset.
+    [non-normative] Typically, E will use the DW_OP_call_frame_cfa operation or
+    be a stack pointer register plus or minus some offset.
     --------------------------------------------------------------------
 
 Replace the paragraph beginning "If a subroutine or entry point is
@@ -1134,15 +1289,16 @@ nested, ..." with the following:
     lexically encloses the current call frame’s subprogram or entry
     point.
 
-    The DWARF is ill-formed if L is is not comprised of one memory
+    The DWARF is ill-formed if L is not comprised of one memory
     location description for one of the target architecture specific
     address spaces.
     --------------------------------------------------------------------
 
 
-In Section 3.4.2 Call Site Parameters, replace the contents of the
-section starting from the second paragraph ("Each
-DW_TAG_call_site_parameter entry...") with the following...
+In Section 3.4.2 Call Site Parameters, replace the contents of the section
+starting from the second paragraph ("Each DW_TAG_call_site_parameter entry...")
+up to the forth paragraph ("For parameters passed by reference, ...") inclusive,
+with the following...
 
     --------------------------------------------------------------------
     A DW_TAG_call_site_parameter debugger information entry may have a
@@ -1216,13 +1372,12 @@ DW_TAG_call_site_parameter entry...") with the following...
     will no longer have the value at the time of the call.
     --------------------------------------------------------------------
 
-In Section 4.1 Data Object Entries, replace item 4 (DW_AT_location) with
-the following:
+In Section 4.1 Data Object Entries, replace the first paragraph of item 4
+(DW_AT_location) with the following:
 
     --------------------------------------------------------------------
-    Any debugging information entry describing a data object (which
-    includes variables and parameters) or common blocks may have a
-    DW_AT_location attribute, whose value is a DWARF expression E.
+    A DW_AT_location attribute, whose value is a DWARF expression E that
+    describes the location of a variable or parameter at run-time.
 
     The result of the attribute is obtained by evaluating E with a
     context that has a result kind of a location description, an
@@ -1265,10 +1420,11 @@ the following:
 > description of any variable regardless of how it is optimized.
 
 In Section 5.7.3 Derived or Extended Structures, Classes and Interfaces,
-in the paragraph about DW_AT_data_member_location, replace the second sentence through the end of the paragraph with the following:
+in the paragraph about DW_AT_data_member_location, replace the second
+sentence through the end of the paragraph with the following:
 
     --------------------------------------------------------------------
-    For a DW_AT_data_member_location attribute there are two cases:
+    There are two cases:
 
      1. If the attribute is an integer constant B, it provides the
         offset in bytes from the beginning of the containing entity.
@@ -1305,10 +1461,8 @@ about DW_AT_vtable_elem_location, with the following:
     --------------------------------------------------------------------
     An entry for a virtual function also has a
     DW_AT_vtable_elem_location attribute whose value is a DWARF
-    expression E.
-
-    The result of the attribute is obtained by evaluating E with a
-    context that has a result kind of a location description, an
+    expression E. The result of the attribute is obtained by evaluating
+    E with a context that has a result kind of a location description, an
     unspecified object, the compilation unit that contains E, an initial
     stack comprising the location description of the object of the
     enclosing type, and other context elements corresponding to the
@@ -1352,7 +1506,7 @@ through eighth paragraphs, about DW_AT_use_location, with the following:
     of the member of the class to which the pointer to member entry points.
     --------------------------------------------------------------------
 
-In Section 5.16 Dynamic Type Entries, append the following at the end:
+In Section 5.18.1 Data Location, replace the second and third paragraphs with:
 
     --------------------------------------------------------------------
     The DW_AT_data_location attribute may be used with any type that

--- a/007-editorial.txt
+++ b/007-editorial.txt
@@ -4,8 +4,6 @@ This is part 7 in a series of proposals related to support for debugging
 on heterogeneous architectures. This proposal is editorial in nature, and
 does not make any substantive changes.
 
-[Work in progress...]
-
 
 BACKGROUND
 ----------
@@ -21,10 +19,214 @@ rearranges the operators into more logical groupings.
 PROPOSED CHANGES
 ----------------
 
-In Section 2.5: DWARF Expressions (p. 26) and Section 2.6 Location
-Descriptions:
+After section 2.5.2 DWARF Expression Value add a new section 2.5.3 DWARF
+Location Description and renumber the following sections. Move the text from
+section 2.6 Location Descriptions (but not its subsections) to the new section.
+Delete the last paragraph that starts with "Location descriptions are
+distinguished in a context sensitive manner...".
 
-Move DW_OP_nop to Control Flow Operations.
+In section 2.5 DWARF Expressions delete the paragraph:
+
+    --------------------------------------------------------------------
+    In addition to the general operations that are defined here, operations that
+    are specific to location descriptions are defined in Section 2.6 on page 38.
+    --------------------------------------------------------------------
+
+In section 2.5.1 DWARF Expression Evaluation Context, change the reference to
+the old section 2.6 Location Descriptions to the new section 2.5.3 DWARF
+Location Description for the descriptions of "A current object" and "An initial
+stack".
+
+Move section 2.5.4.3 Stack Operations to be the first subsection of 2.5.4 DWARF
+Operation Expressions and move section 2.5.4.5 Control Flow Operations to be the
+second subsection.
+
+Add a new third subsection of 2.5.4 DWARF Operation Expressions named 2.5.4.3
+Value Operations:
+
+    --------------------------------------------------------------------
+    2.5.4.3 Value Operations
+
+    This section describes the operations that push values on the stack.
+
+    Each value stack entry has a type and a literal value. It can represent a
+    literal value of any supported base type of the target architecture. The
+    base type specifies the size, encoding, and endianity of the literal value.
+
+    The base type of value stack entries can be the distinguished generic type.
+    --------------------------------------------------------------------
+
+In the new section 2.5.4.1 Stack Operations delete the following paragraph:
+
+    --------------------------------------------------------------------
+    Each entry on the stack has an associated type.
+    --------------------------------------------------------------------
+
+and change the description of the following operations:
+
+    --------------------------------------------------------------------
+    1.  DW_OP_dup
+        DW_OP_dup duplicates the stack entry at the top of the stack.
+
+    2.  DW_OP_drop
+        DW_OP_drop pops the stack entry at the top of the stack and discards it.
+
+    3.  DW_OP_pick
+        ...
+
+    4.  DW_OP_over
+        ...
+
+    5.  DW_OP_swap
+        DW_OP_swap swaps the top two stack entries. The entry at the top of the
+        stack becomes the second stack entry, and the second stack entry becomes
+        the top of the stack.
+
+    6.  DW_OP_rot
+        DW_OP_rot rotates the first three stack entries. The entry at the top of
+        the stack becomes the third stack entry, the second entry becomes the
+        top of the stack, and the third entry becomes the second entry.
+    --------------------------------------------------------------------
+
+In the new section 2.5.4.2 Control Flow Operations, change "DWARF expression" to
+"DWARF operation expression" in the the first paragraph and the description of
+DW_OP_bra.
+
+Move DW_OP_nop to be the first operation in the new section 2.5.4.2 Control Flow
+Operations, and change the description to:
+
+    --------------------------------------------------------------------
+    1.  DW_OP_nop
+        DW_OP_nop is a place holder. It has no effect on the DWARF stack
+        entries.
+    --------------------------------------------------------------------
+
+Renumber the following operations in the same section.
+
+In the description of DW_OP_call2/call4/call_ref, add Oxford comma before "and"
+to be consistent, and delete the final section 7.5.4 reference (which does not
+seem to be an appropriate section, 7.5.6 would be a better section but other
+mentions of these forms do not link to that section either):
+
+    --------------------------------------------------------------------
+    Operand interpretation of DW_OP_call2, DW_OP_call4, and DW_OP_call_ref is
+    exactly like that for DW_FORM_ref2, DW_FORM_ref4, and DW_FORM_ref_addr,
+    respectively.
+    --------------------------------------------------------------------
+
+Move the old section 2.5.4.1 Literal Encodings to be the first subsection of
+section 2.5.4.3 Value Operations and rename to section 2.5.4.3.1 Literal
+Operations.
+
+Move the old section 2.5.4.4 Arithmetic and Logical Operations to be the second
+subsection of section 2.5.4.3 Value Operations, becoming section 2.5.4.3.2
+Arithmetic and Logical Operations.
+
+Move the old section 2.5.4.6 Type Conversions to be the third subsection of
+section 2.5.4.3 Value Operations and rename to section 2.5.4.3.3 Type Conversion
+Operations.
+
+Move the old section 2.5.4.7 Special Operations to be the forth subsection of
+section 2.5.4.3 Value Operations and rename to section 2.5.4.3.4 Special Value
+Operations. In the first paragraph change "special operations" to "special value
+operations".
+
+Move the following operations into section 2.5.4.3.4 Special Value Operations
+before DW_OP_entry_value:
+
+    --------------------------------------------------------------------
+    1.  DW_OP_regval_type
+        ...
+
+    2.  DW_OP_deref
+        ...
+
+    3.  DW_OP_deref_size
+        ...
+
+    4.  DW_OP_deref_type
+        ...
+
+    5.  DW_OP_xderef
+        ...
+
+    6.  DW_OP_xderef_size
+        ...
+
+    7.  DW_OP_xderef_type
+        ...
+    
+    8.  DW_OP_entry_value [same]
+        ...
+    --------------------------------------------------------------------
+
+Delete old section 2.5.4.2 Register Values, but save the text for the
+DW_OP_fbreg, DW_OP_breg<N>, and DW_OP_bregx operations to be moved the new
+section 2.5.4.4.3 Memory Location Description Operations.
+
+Move and rename old section 2.6 Location Descriptions to 2.5.4.4 Location
+Description Operations. Add the following as its only paragraph:
+
+    --------------------------------------------------------------------
+    This section describes the operations that push location descriptions on the
+    stack.
+    --------------------------------------------------------------------
+
+Add new section 2.5.4.4.1 General Location Description Operations as the first
+subsection of 2.5.4.4 Location Description Operations. Move the description of
+DW_OP_push_object_address to the new subsection.
+
+Move old section 2.6.1 Undefined Location Description Operations to be the
+second subsection of 2.5.4.4 Location Description Operations and so numbered
+2.5.4.4.2.
+
+Move old section 2.6.2 Memory Location Descriptions to be the third subsection
+of 2.5.4.4 Location Description Operations and rename to 2.5.4.4.3 Memory
+Location Description Operations. Delete the first paragraph:
+
+    --------------------------------------------------------------------
+    A memory location description consists of a non-empty DWARF expression (see
+    Section 2.5 on page 26), whose value is the address of a piece or all of an
+    object or other entity in memory.
+    --------------------------------------------------------------------
+
+Move the following operations to the end of the new section 2.5.4.4.3 Memory
+Location Description Operations:
+
+    --------------------------------------------------------------------
+    1.  DW_OP_addr
+        ...
+
+    2.  DW_OP_addrx
+        ...
+
+    3.  DW_OP_form_tls_address
+        ...
+
+    4.  DW_OP_call_frame_cfa
+        ...
+
+    5.  DW_OP_fbreg
+        ...
+
+    6.  DW_OP_breg0, DW_OP_breg1, ..., DW_OP_breg31
+        ...
+
+    7.  DW_OP_bregx
+        ...
+    --------------------------------------------------------------------
+
+Move section 2.6.3 Register Location Description Operations to be the forth
+subsection of 2.5.4.4 Location Description Operations and numbered to 2.5.4.4.4.
+
+Move section 2.6.4 Implicit Location Description Operations to be the fifth
+subsection of 2.5.4.4 Location Description Operations and numbered to 2.5.4.4.5.
+
+Move section 2.6.5 Composite Location Description Operations to be the sixth
+subsection of 2.5.4.4 Location Description Operations and numbered to 2.5.4.4.6.
+
+Move and rename section 2.6.6 Location List Expressions to be 2.5.5 DWARF
+Location List Expressions.
 
 Rename Section 7.7 from "DWARF Expressions and Location Descriptions" to
 "DWARF Expressions" (to reflect the unification of location descriptions
@@ -34,5 +236,5 @@ Rename Section 7.7.1 from "DWARF Expressions" to "Operation Expressions."
 
 Delete Section 7.7.2, Location Descriptions.
 
-Rename (and renumber) Section 7.7.3 from "Location Lists" to "Location
-List Expressions."
+Rename (and renumber) Section "7.7.3 Location Lists" to "7.7.2 Location List
+Expressions."


### PR DESCRIPTION
1. The paragraph:

     [non-normative] The generic type is the same as the unspecified
     type used for stack operations defined in DWARF Version 4 and
     before.

   is already part of DWARF 5, so do not repeat it.

2. Mark bulleted list.

3. Mark [non-normative].

4. Clarify that the "same value CFI rule changes is adding paragraphs.

5. "val_offset(N)" register rule last paragraph is non-normative.

6. For the "register(R)" register rule, change the wording of the4 first paragraph.

7. Update description of DW_CFA_def_cfa_sf.

8. Update text for DW_CFA_val_offset_sf.

9. Rename 005-address-spaces.txt to 005-clarification-mem.txt and reword introductory text. Removed mention of DW_ASPACE_none and moved to Generalized Address Space Support pull request.

10. "Operations represents" -> "Operations represent"

11. Second occurrence of "If the current result kind specifies a location description," -> "If the current result kind specifies a value,".

12. The following paragraph was duplicated with a different referenced section. Remove duplicate and put correct version in he right place.

      See 2.5.x.x Implicit Location Description Operations for special
      rules concerning implicit location descriptions created by the
      DW_OP_implicit_pointer operation.

13. Correction to "Memory Location Descriptions" in 006-locations-on-stack.txt.

14. Fix long line.

15. Changes to opening paragraphs of "Implicit Location Description Operations" section.

16. "A location list consists" -> "A location list expression consists"

17. Add paragraph to "Default location description".

18. "is is" -> "is"

19. Clarify which paragraphs are being updated in Section 3.4.2 Call Site Parameters.

20. Clarify the text to update for the DW_AT_location attribute.

21. Section 5.7.3 Derived or Extended Structures, reword text.

22. Section 5.7.8 Member Function Entries, made a single paragraph to match the rest of the section.

23. Correct section to update for DW_AT_data_location.

24. "For example:" -> "For example," to match rest of specification.