### PR TITLE
expression(e) is in section 6.4.1

### DIFF
--- a/005-locations-on-stack.md
+++ b/005-locations-on-stack.md
@@ -791,7 +791,7 @@ Replace the paragraph beginning "The `DW_AT_use_location` description..." with:
 > is being calculated.
 
 
-### Section 6.4 Call Frame Information
+### Section 6.4.1 Structure of Call Frame Information
 
 For the "expression(E)" register rule, change the description to:
 


### PR DESCRIPTION
The text cited for the change is in section 6.4.1 Structure of Call Frame Information not in 6.4 Call Frame Information